### PR TITLE
Add a check for undefined tera types

### DIFF
--- a/script.js
+++ b/script.js
@@ -314,6 +314,10 @@ function generatePdf(element) {
 
             var name = window['pokes' + chosenLang][nameId];
             var teraType = window['types' + chosenLang][teraTypeId];
+            if (teraType == undefined)
+            {
+                teraType = "None";
+            }
             var ability = window['abilities' + chosenLang][abilityId];
             var item = 'NO ITEM';
             if (itemId != 'NOITEM'){


### PR DESCRIPTION
A friend of mine ran into this issue where Smogon's Team Builder no longer includes Tera Types in their copy/paste bin. I dug in and found out that it breaks this website that they really like. Really simple fix. Feel free to let me know if it doesn't follow any of your standards and I'll be happy to update.